### PR TITLE
fix: use daemon threads for conn pool and poller

### DIFF
--- a/src/amplitude_experiment/connection_pool.py
+++ b/src/amplitude_experiment/connection_pool.py
@@ -164,6 +164,7 @@ class HTTPConnectionPool:
             return
         self.clear_idle_conn()
         self._clearer = threading.Timer(self.idle_timeout, self.start_clear_conn)
+        self._clearer.daemon = True
         self._clearer.start()
 
     def stop_clear_conn(self) -> None:

--- a/src/amplitude_experiment/local/poller.py
+++ b/src/amplitude_experiment/local/poller.py
@@ -26,6 +26,7 @@ class Poller:
                 self.next_call = time.time()
             self.next_call += self.interval
             self._timer = threading.Timer(self.next_call - time.time(), self._run)
+            self._timer.daemon = True
             self._timer.start()
             self.is_running = True
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Experiment Python Server SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

Exit signals were not ending the process since the connection pool and poller threads were not set to daemon mode.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-python-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> No
