### PR TITLE
fix: Allow creation of multiple client instances based on api key

### DIFF
--- a/src/amplitude_experiment/factory.py
+++ b/src/amplitude_experiment/factory.py
@@ -5,7 +5,6 @@ from .local.config import LocalEvaluationConfig
 
 remote_evaluation_instances = {}
 local_evaluation_instances = {}
-default_instance = '$default_instance'
 
 
 class Experiment:
@@ -23,9 +22,9 @@ class Experiment:
             Returns:
                 The remote evaluation client.
         """
-        if remote_evaluation_instances.get(default_instance) is None:
-            remote_evaluation_instances[default_instance] = RemoteEvaluationClient(api_key, config)
-        return remote_evaluation_instances[default_instance]
+        if remote_evaluation_instances.get(api_key) is None:
+            remote_evaluation_instances[api_key] = RemoteEvaluationClient(api_key, config)
+        return remote_evaluation_instances[api_key]
 
     @staticmethod
     def initialize_local(api_key: str, config: LocalEvaluationConfig = None) -> LocalEvaluationClient:
@@ -40,6 +39,6 @@ class Experiment:
             Returns:
                 The local evaluation client.
         """
-        if local_evaluation_instances.get(default_instance) is None:
-            local_evaluation_instances[default_instance] = LocalEvaluationClient(api_key, config)
-        return local_evaluation_instances[default_instance]
+        if local_evaluation_instances.get(api_key) is None:
+            local_evaluation_instances[api_key] = LocalEvaluationClient(api_key, config)
+        return local_evaluation_instances[api_key]

--- a/src/amplitude_experiment/factory.py
+++ b/src/amplitude_experiment/factory.py
@@ -8,19 +8,18 @@ local_evaluation_instances = {}
 
 
 class Experiment:
-    """Provides factory methods for storing singleton instance of Client"""
+    """Provides factory methods for storing instances of Client"""
 
     @staticmethod
     def initialize_remote(api_key: str, config: RemoteEvaluationConfig = None) -> RemoteEvaluationClient:
         """
-        Initializes a singleton Client. This method returns a default singleton instance, subsequent calls to
-        init will return the initial instance regardless of input.
+        Initializes a remote evaluation client.
             Parameters:
                 api_key (str): The Amplitude API Key
                 config (RemoteEvaluationConfig): Optional Config
 
             Returns:
-                The remote evaluation client.
+                A remote evaluation client.
         """
         if remote_evaluation_instances.get(api_key) is None:
             remote_evaluation_instances[api_key] = RemoteEvaluationClient(api_key, config)
@@ -37,7 +36,7 @@ class Experiment:
                 config (RemoteEvaluationConfig): Optional Config
 
             Returns:
-                The local evaluation client.
+                A local evaluation client.
         """
         if local_evaluation_instances.get(api_key) is None:
             local_evaluation_instances[api_key] = LocalEvaluationClient(api_key, config)


### PR DESCRIPTION
### Summary

Fix: Allow creation of multiple client instances based on api key

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-python-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
