### PR TITLE
fix: Do not track empty assignment events

### DIFF
--- a/src/amplitude_experiment/assignment/assignment_filter.py
+++ b/src/amplitude_experiment/assignment/assignment_filter.py
@@ -8,6 +8,8 @@ class AssignmentFilter:
         self.cache = Cache(size, ttl_millis)
 
     def should_track(self, assignment: Assignment) -> bool:
+        if not assignment.results:
+            return False
         canonical_assignment = assignment.canonicalize()
         track = self.cache.get(canonical_assignment) is None
         if track:

--- a/src/amplitude_experiment/local/client.py
+++ b/src/amplitude_experiment/local/client.py
@@ -69,8 +69,6 @@ class LocalEvaluationClient:
         """
         variants = {}
         if self.flags is None or len(self.flags) == 0:
-            if self.assignment_service:
-                self.assignment_service.track(Assignment(user, {}))
             return variants
         user_json = str(user)
         self.logger.debug(f"[Experiment] Evaluate: User: {user_json} - Flags: {self.flags}")

--- a/tests/local/assignment/assignment_filter_test.py
+++ b/tests/local/assignment/assignment_filter_test.py
@@ -67,9 +67,9 @@ class AssignmentFilterTestCase(unittest.TestCase):
         assignment1 = Assignment(user1, {})
         assignment2 = Assignment(user1, {})
         assignment3 = Assignment(user2, {})
-        self.assertTrue(assignment_filter.should_track(assignment1))
+        self.assertFalse(assignment_filter.should_track(assignment1))
         self.assertFalse(assignment_filter.should_track(assignment2))
-        self.assertTrue(assignment_filter.should_track(assignment3))
+        self.assertFalse(assignment_filter.should_track(assignment3))
 
     def test_duplicate_assignments_with_different_ordering(self):
         assignment_filter = AssignmentFilter(100)

--- a/tests/local/assignment/assignment_service_test.py
+++ b/tests/local/assignment/assignment_service_test.py
@@ -39,5 +39,8 @@ class AssignmentServiceTestCase(unittest.TestCase):
         instance = Amplitude('')
         instance.track = MagicMock()
         service = AssignmentService(instance, AssignmentFilter(2))
-        service.track(Assignment(user, {}))
+        results = {}
+        result = FlagResult({'variant': {'key': 'on'}, 'isDefaultVariant': False})
+        results['flag-key-1'] = result
+        service.track(Assignment(user, results))
         self.assertTrue(instance.track.called)


### PR DESCRIPTION
### Summary

Employ fix: empty assignment events are not tracked

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-python-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
