### PR TITLE
using user_properties defined from user

### DIFF
--- a/src/amplitude_experiment/assignment/assignment_service.py
+++ b/src/amplitude_experiment/assignment/assignment_service.py
@@ -10,7 +10,7 @@ FLAG_TYPE_HOLDOUT_GROUP = "holdout-group"
 
 def to_event(assignment: Assignment) -> BaseEvent:
     event = BaseEvent(event_type='[Experiment] Assignment', user_id=assignment.user.user_id,
-                      device_id=assignment.user.device_id, event_properties={}, user_properties={})
+                      device_id=assignment.user.device_id, event_properties={}, user_properties=assignment.user.user_properties)
     set_props = {}
     unset_props = {}
 

--- a/tests/local/assignment/assignment_service_test.py
+++ b/tests/local/assignment/assignment_service_test.py
@@ -8,7 +8,7 @@ from src.amplitude_experiment import User
 from src.amplitude_experiment.assignment import AssignmentFilter, Assignment, DAY_MILLIS, to_event, AssignmentService
 from src.amplitude_experiment.util import hash_code
 
-user = User(user_id='user', device_id='device')
+user = User(user_id='user', device_id='device', user_properties={'premium': True})
 
 
 class AssignmentServiceTestCase(unittest.TestCase):
@@ -82,6 +82,7 @@ class AssignmentServiceTestCase(unittest.TestCase):
         # Validate user properties
         user_properties = event.user_properties
         set_properties = user_properties['$set']
+        self.assertTrue(user_properties['premium']) 
         self.assertEqual('control', set_properties['[Experiment] basic'])
         self.assertEqual('on', set_properties['[Experiment] different_value'])
         self.assertEqual('holdout', set_properties['[Experiment] holdout'])


### PR DESCRIPTION
Enabling external `user_properties` as described in [documentation quick start](https://amplitude.com/docs/sdks/experiment-sdks/experiment-python) to Assignment Experiment Event


### Checklist

* ? Does your PR title have the correct [title format](https://github.com/amplitude/experiments-python-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)? I'm receiving 404 on that
* Does your PR have a breaking change?  No
