### PR TITLE
fix: add sseclient-py to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "Programming Language :: Python :: 3.10",
     ],
     keywords="amplitude, python, backend",
-    install_requires=["dataclasses-json>=0.6.7","amplitude_analytics>=1.1.1"],
+    install_requires=["dataclasses-json>=0.6.7","amplitude_analytics>=1.1.1","sseclient-py~=1.8.0"],
     package_dir={"": "src"},
     packages=["amplitude_experiment"],
     include_package_data=True,


### PR DESCRIPTION
fix `ModuleNotFoundError: No module named 'sseclient'` in 1.8.0

<!---
Thanks for contributing to the Amplitude Experiment Python Server SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-python-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
