### PR TITLE
[log] reduce useless logs such as "[Experiment] Fetch failed: [Errno 104] Connection reset by peer"

### DIFF
--- a/src/amplitude_experiment/remote/client.py
+++ b/src/amplitude_experiment/remote/client.py
@@ -111,9 +111,9 @@ class RemoteEvaluationClient:
         try:
             return self.__do_fetch(user, fetch_options)
         except Exception as e:
-            self.logger.error(f"[Experiment] Fetch failed: {e}")
             if self.__should_retry_fetch(e):
                 return self.__retry_fetch(user, fetch_options)
+            self.logger.error(f"[Experiment] Fetch failed: {e}", exc_info=e)
 
     def __retry_fetch(self, user, fetch_options: FetchOptions = None):
         if self.config.fetch_retries == 0:
@@ -126,7 +126,7 @@ class RemoteEvaluationClient:
             try:
                 return self.__do_fetch(user, fetch_options)
             except Exception as e:
-                self.logger.error(f"[Experiment] Retry failed: {e}")
+                self.logger.error(f"[Experiment] Retry failed: {e}", exc_info=e)
                 err = e
             delay_millis = min(delay_millis * self.config.fetch_retry_backoff_scalar,
                                self.config.fetch_retry_backoff_max_millis)


### PR DESCRIPTION
Hi, team!

I'm observing too many `[Experiment] Fetch failed: [Errno 104] Connection reset by peer` logs issued to Sentry, but they are useless becasue:

* It is not useful because the logs are emitted when retry is being performed -- only useful if all the retries are failed.
* It is not informative because no exception info is attached.

So this PR deals with these two problems.
