### PR TITLE
ci: harden supply chain security for release pipelines

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,15 +2,18 @@ name: Publish Docs
 
 on: workflow_dispatch
 
+permissions:
+  contents: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
 
       - name: Set up pdoc
         run:  pip install pdoc3
@@ -19,7 +22,7 @@ jobs:
         run:  pdoc ./src/amplitude_experiment -o ./docs --html
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4.1.5
+        uses: JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8 # v4.7.3
         with:
           branch: gh-pages
           folder: docs/amplitude_experiment

--- a/.github/workflows/jira-issue-create.yml
+++ b/.github/workflows/jira-issue-create.yml
@@ -5,6 +5,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  issues: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -12,7 +15,7 @@ jobs:
     name: SDK Bot Jira Issue Creation
     steps:
       - name: Login
-        uses: atlassian/gajira-login@master
+        uses: atlassian/gajira-login@45fd029b9f1d6d8926c6f04175aa80c0e42c9026 # v3.0.1
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
@@ -20,7 +23,7 @@ jobs:
 
       - name: Create issue
         id: create
-        uses: atlassian/gajira-create@master
+        uses: atlassian/gajira-create@59e177c4f6451399df5b4911c2211104f171e669 # v3.0.1
         with:
           project: ${{ secrets.JIRA_PROJECT }}
           issuetype: Task

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -8,31 +8,35 @@ on:
         required: true
         default: 'true'
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   authorize:
     name: Authorize
     runs-on: ubuntu-latest
     steps:
       - name: ${{ github.actor }} permission check to do a release
-        uses: "lannonbr/repo-permission-check-action@2.0.2"
+        uses: "lannonbr/repo-permission-check-action@2bb8c89ba8bf115c4bfab344d6a6f442b24c9a1f" # v2.0.2
         with:
           permission: "write"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-n-publish:
-    environment: Unit Test
+    environment: PyPI Release
     name: Build and publish to PyPI
     runs-on: ubuntu-latest
     needs: [authorize]
     steps:
       - name: Checkout for release to PyPI
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 3.8
 
@@ -56,6 +60,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           semantic-release publish --noop
+
       - name: Publish distribution PyPI
         if: ${{ github.event.inputs.dryRun == 'false'}}
         run: |
@@ -64,5 +69,7 @@ jobs:
           semantic-release publish
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPOSITORY_USERNAME: __token__
-          REPOSITORY_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Publish to PyPI via trusted publishing
+        if: ${{ github.event.inputs.dryRun == 'false' }}
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -2,13 +2,17 @@ name: Publish to TestPyPI
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   authorize:
     name: Authorize
     runs-on: ubuntu-latest
     steps:
       - name: ${{ github.actor }} permission check to do a release
-        uses: "lannonbr/repo-permission-check-action@2.0.2"
+        uses: "lannonbr/repo-permission-check-action@2bb8c89ba8bf115c4bfab344d6a6f442b24c9a1f" # v2.0.2
         with:
           permission: "write"
         env:
@@ -18,11 +22,13 @@ jobs:
     name: Build and publish to TestPyPI
     runs-on: ubuntu-latest
     needs: [authorize]
+    environment: TestPyPI Release
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 3.8
 
@@ -32,9 +38,7 @@ jobs:
       - name: Build a binary wheel and a source tarball
         run: python -m build --sdist --wheel --outdir dist/ .
 
-      - name: Publish distribution Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish distribution to TestPyPI via trusted publishing
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, edited]
 
+permissions:
+  pull-requests: read
+
 jobs:
   pr-title-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -15,10 +18,10 @@ jobs:
         python-version: [ "3.8", "3.12", "3.14" ]
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version_variable = [
 ]
 major_on_zero = true
 branch = "main"
-upload_to_PyPI = true
+upload_to_PyPI = false
 upload_to_release = true
 build_command = "pip install build && python -m build"
 version_source = "commit"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

Audit and secure the release pipeline for `experiment-python-server` per the supply chain security actions defined in [SKY-10076](https://amplitude.atlassian.net/browse/SKY-10076) (OIDC migration, SHA-pinned actions, approval gates, allowed actions policy).

Resolves [SKY-10115](https://amplitude.atlassian.net/browse/SKY-10115).

#### SHA-Pinned Actions
All external GitHub Actions across all 6 workflow files are now pinned to full commit SHAs instead of mutable version tags. This prevents supply chain attacks where an attacker could modify the action code behind a version tag. Each SHA is annotated with a comment indicating the version for maintainability.

| Action | Before | After (SHA) |
|--------|--------|-------------|
| `actions/checkout` | `@v2` / `@v3` | `@11bd71901bbe...` (v4.2.2) |
| `actions/setup-python` | `@v6` | `@a26af69be951...` (v5.6.0) |
| `lannonbr/repo-permission-check-action` | `@2.0.2` | `@2bb8c89ba8bf...` (v2.0.2) |
| `pypa/gh-action-pypi-publish` | `@release/v1` | `@76f52bc88423...` (v1.12.4) |
| `JamesIves/github-pages-deploy-action` | `@4.1.5` | `@6c2d9db40f92...` (v4.7.3) |
| `atlassian/gajira-login` | `@master` | `@45fd029b9f1d...` (v3.0.1) |
| `atlassian/gajira-create` | `@master` | `@59e177c4f645...` (v3.0.1) |

#### OIDC Migration (Trusted Publishing)
- **publish-to-pypi.yml**: Replaced static `PYPI_API_TOKEN` secret with OIDC-based trusted publishing via `pypa/gh-action-pypi-publish`. `semantic-release` now only handles versioning/tagging (upload disabled in `pyproject.toml`), and the actual PyPI upload is done via OIDC.
- **publish-to-test-pypi.yml**: Replaced static `TEST_PYPI_API_TOKEN` secret with OIDC-based trusted publishing.
- Added `id-token: write` permission to both publish workflows to enable OIDC token generation.

> **Note**: Trusted publishing must be configured on [PyPI](https://docs.pypi.org/trusted-publishers/) and [TestPyPI](https://test.pypi.org/manage/account/publishing/) for this repository before the next release. The trusted publisher should be configured with the repository `amplitude/experiment-python-server`, workflow `publish-to-pypi.yml` (and `publish-to-test-pypi.yml` for TestPyPI), and the environment names `PyPI Release` / `TestPyPI Release`.

#### Approval Gates
- Added `environment: PyPI Release` to the production publish job (requires environment approval before release)
- Added `environment: TestPyPI Release` to the test publish job
- These environments should be configured in GitHub repository settings with required reviewers

#### Permissions Hardening
Added explicit top-level `permissions` blocks to all workflow files following the principle of least privilege:
- `test.yml`: `contents: read`
- `publish-to-pypi.yml`: `contents: write` + `id-token: write`
- `publish-to-test-pypi.yml`: `contents: read` + `id-token: write`
- `docs.yml`: `contents: write`
- `semantic-pr.yml`: `pull-requests: read`
- `jira-issue-create.yml`: `issues: read`

#### Configuration Changes
- `pyproject.toml`: Set `upload_to_PyPI = false` so `semantic-release` skips the direct upload (now handled by the OIDC action)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-python-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5a17edf-0393-46aa-859a-b1aba7e36052"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5a17edf-0393-46aa-859a-b1aba7e36052"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[SKY-10076]: https://amplitude.atlassian.net/browse/SKY-10076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SKY-10115]: https://amplitude.atlassian.net/browse/SKY-10115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ