### PR TITLE
ci: harden supply chain security for release pipelines

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,2 @@
-# Workflow and release automation files require review from SDK team
-/.github/workflows/ @amplitude/sdk
-/.github/CODEOWNERS @amplitude/sdk
-
-# Package metadata and build configuration
-/setup.py @amplitude/sdk
-/pyproject.toml @amplitude/sdk
+# Default: require experiment-sdk team review for all files
+* @amplitude/experiment-sdk

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Workflow and release automation files require review from SDK team
+/.github/workflows/ @amplitude/sdk
+/.github/CODEOWNERS @amplitude/sdk
+
+# Package metadata and build configuration
+/setup.py @amplitude/sdk
+/pyproject.toml @amplitude/sdk

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
 
       - name: Set up pdoc
         run:  pip install pdoc3
@@ -19,7 +19,7 @@ jobs:
         run:  pdoc ./src/amplitude_experiment -o ./docs --html
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4.1.5
+        uses: JamesIves/github-pages-deploy-action@0f24da7de3e7e135102609a4c9633b025be8411b # 4.1.5
         with:
           branch: gh-pages
           folder: docs/amplitude_experiment

--- a/.github/workflows/jira-issue-create.yml
+++ b/.github/workflows/jira-issue-create.yml
@@ -12,7 +12,7 @@ jobs:
     name: SDK Bot Jira Issue Creation
     steps:
       - name: Login
-        uses: atlassian/gajira-login@master
+        uses: atlassian/gajira-login@c22a5debd482401472b285de4f6deedf70ddbb92 # master
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
@@ -20,7 +20,7 @@ jobs:
 
       - name: Create issue
         id: create
-        uses: atlassian/gajira-create@master
+        uses: atlassian/gajira-create@1c54357fdde9dab6273a0e26d67cb175ffffe498 # master
         with:
           project: ${{ secrets.JIRA_PROJECT }}
           issuetype: Task

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -14,25 +14,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ${{ github.actor }} permission check to do a release
-        uses: "lannonbr/repo-permission-check-action@2.0.2"
+        uses: lannonbr/repo-permission-check-action@2bb8c89ba8bf115c4bfab344d6a6f442b24c9a1f # 2.0.2
         with:
           permission: "write"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-n-publish:
-    environment: Unit Test
+    environment: pypi
     name: Build and publish to PyPI
     runs-on: ubuntu-latest
     needs: [authorize]
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout for release to PyPI
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: 3.8
 
@@ -56,7 +59,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           semantic-release publish --noop
-      - name: Publish distribution PyPI
+
+      - name: Version, tag, and release
         if: ${{ github.event.inputs.dryRun == 'false'}}
         run: |
           git config user.name amplitude-sdk-bot
@@ -64,5 +68,11 @@ jobs:
           semantic-release publish
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPOSITORY_USERNAME: __token__
-          REPOSITORY_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Build package
+        if: ${{ github.event.inputs.dryRun == 'false'}}
+        run: python -m build
+
+      - name: Publish to PyPI
+        if: ${{ github.event.inputs.dryRun == 'false'}}
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -61,6 +61,12 @@ jobs:
           push: false
           vcs_release: false
 
+      - name: Publish to Test PyPI
+        if: ${{ github.event.inputs.dryRun == 'true'}}
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        with:
+          repository-url: https://test.pypi.org/legacy/
+  
       - name: Python Semantic Release
         if: ${{ github.event.inputs.dryRun == 'false'}}
         uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10.5.3
@@ -70,9 +76,3 @@ jobs:
       - name: Publish to PyPI
         if: ${{ github.event.inputs.dryRun == 'false'}}
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
-
-      - name: Publish to Test PyPI
-        if: ${{ github.event.inputs.dryRun == 'true'}}
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
-        with:
-          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -21,7 +21,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-n-publish:
-    environment: pypi
+    environment: Unit Test
     name: Build and publish to PyPI
     runs-on: ubuntu-latest
     needs: [authorize]
@@ -40,7 +40,7 @@ jobs:
           python-version: 3.8
 
       - name: Install dependencies
-        run: python -m pip install build setuptools wheel twine amplitude_analytics parameterized python-dotenv~=0.21.1 python-semantic-release==7.34.6
+        run: python -m pip install build setuptools wheel twine amplitude_analytics parameterized python-dotenv~=0.21.1 python-semantic-release==10.5.3
 
       - name: Install requirements
         run: pip install -r requirements.txt && pip install -r requirements-dev.txt
@@ -55,24 +55,24 @@ jobs:
 
       - name: Publish distribution PyPI --dry-run
         if: ${{ github.event.inputs.dryRun == 'true'}}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          semantic-release publish --noop
+        uses: python-semantic-release/python-semantic-release@v10.5.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          push: false
+          vcs_release: false
 
-      - name: Version, tag, and release
+      - name: Python Semantic Release
         if: ${{ github.event.inputs.dryRun == 'false'}}
-        run: |
-          git config user.name amplitude-sdk-bot
-          git config user.email amplitude-sdk-bot@users.noreply.github.com
-          semantic-release publish
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build package
-        if: ${{ github.event.inputs.dryRun == 'false'}}
-        run: python -m build
+        uses: python-semantic-release/python-semantic-release@v10.5.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to PyPI
         if: ${{ github.event.inputs.dryRun == 'false'}}
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+
+      - name: Publish to Test PyPI
+        if: ${{ github.event.inputs.dryRun == 'true'}}
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -40,7 +40,7 @@ jobs:
           python-version: 3.8
 
       - name: Install dependencies
-        run: python -m pip install build setuptools wheel twine amplitude_analytics parameterized python-dotenv~=0.21.1 python-semantic-release==10.5.3
+        run: python -m pip install build setuptools wheel twine amplitude_analytics parameterized python-dotenv~=0.21.1
 
       - name: Install requirements
         run: pip install -r requirements.txt && pip install -r requirements-dev.txt
@@ -55,7 +55,7 @@ jobs:
 
       - name: Publish distribution PyPI --dry-run
         if: ${{ github.event.inputs.dryRun == 'true'}}
-        uses: python-semantic-release/python-semantic-release@v10.5.3
+        uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10.5.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           push: false
@@ -63,7 +63,7 @@ jobs:
 
       - name: Python Semantic Release
         if: ${{ github.event.inputs.dryRun == 'false'}}
-        uses: python-semantic-release/python-semantic-release@v10.5.3
+        uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10.5.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -53,7 +53,7 @@ jobs:
           EU_SECRET_KEY: ${{ secrets.EU_SECRET_KEY }}
         run: python -m unittest discover -s ./tests -p '*_test.py'
 
-      - name: Publish distribution PyPI --dry-run
+      - name: Python Semantic Release --dry-run
         if: ${{ github.event.inputs.dryRun == 'true'}}
         uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10.5.3
         with:

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -53,8 +53,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           push: false
           vcs_release: false
-          prerelease: true
-          prerelease_token: alpha
 
       - name: Publish to Test PyPI
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ${{ github.actor }} permission check to do a release
-        uses: "lannonbr/repo-permission-check-action@2.0.2"
+        uses: lannonbr/repo-permission-check-action@2bb8c89ba8bf115c4bfab344d6a6f442b24c9a1f # 2.0.2
         with:
           permission: "write"
         env:
@@ -18,11 +18,14 @@ jobs:
     name: Build and publish to TestPyPI
     runs-on: ubuntu-latest
     needs: [authorize]
+    environment: testpypi
+    permissions:
+      id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: 3.8
 
@@ -33,8 +36,6 @@ jobs:
         run: python -m build --sdist --wheel --outdir dist/ .
 
       - name: Publish distribution Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -20,6 +20,7 @@ jobs:
     needs: [authorize]
     environment: Unit Test
     permissions:
+      contents: read
       id-token: write
     steps:
       - name: Checkout for release to PyPI

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: 3.8
 
       - name: Install dependencies
-        run: python -m pip install build setuptools wheel twine amplitude_analytics parameterized python-dotenv~=0.21.1 python-semantic-release==10.5.3
+        run: python -m pip install build setuptools wheel twine amplitude_analytics parameterized python-dotenv~=0.21.1
 
       - name: Install requirements
         run: pip install -r requirements.txt && pip install -r requirements-dev.txt
@@ -47,7 +47,7 @@ jobs:
         run: python -m unittest discover -s ./tests -p '*_test.py'
 
       - name: Publish distribution PyPI --dry-run
-        uses: python-semantic-release/python-semantic-release@v10.5.3
+        uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10.5.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           push: false

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -53,6 +53,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           push: false
           vcs_release: false
+          prerelease: true
+          prerelease_token: alpha
 
       - name: Publish to Test PyPI
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -18,11 +18,14 @@ jobs:
     name: Build and publish to TestPyPI
     runs-on: ubuntu-latest
     needs: [authorize]
-    environment: testpypi
+    environment: Unit Test
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - name: Checkout for release to PyPI
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          fetch-depth: 0
 
       - name: Set up Python 3.8
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -30,12 +33,27 @@ jobs:
           python-version: 3.8
 
       - name: Install dependencies
-        run: python -m pip install build setuptools wheel twine amplitude_analytics parameterized
+        run: python -m pip install build setuptools wheel twine amplitude_analytics parameterized python-dotenv~=0.21.1 python-semantic-release==10.5.3
 
-      - name: Build a binary wheel and a source tarball
-        run: python -m build --sdist --wheel --outdir dist/ .
+      - name: Install requirements
+        run: pip install -r requirements.txt && pip install -r requirements-dev.txt
+      
+      - name: Run Test
+        env:
+          API_KEY: ${{ secrets.API_KEY }}
+          SECRET_KEY: ${{ secrets.SECRET_KEY }}
+          EU_API_KEY: ${{ secrets.EU_API_KEY }}
+          EU_SECRET_KEY: ${{ secrets.EU_SECRET_KEY }}
+        run: python -m unittest discover -s ./tests -p '*_test.py'
 
-      - name: Publish distribution Test PyPI
+      - name: Publish distribution PyPI --dry-run
+        uses: python-semantic-release/python-semantic-release@v10.5.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          push: false
+          vcs_release: false
+
+      - name: Publish to Test PyPI
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
         python-version: [ "3.8" ]
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,15 @@
 [tool.semantic_release]
-version_variable = [
+version_variables = [
     "src/amplitude_experiment/version.py:__version__"
 ]
 major_on_zero = true
-branch = "main"
-upload_to_PyPI = false
-upload_to_release = true
 build_command = "pip install build && python -m build"
-version_source = "commit"
-commit_version_number = true
-commit_subject = "chore(release): Bump version to {version}"
 commit_message = "chore(release): Bump version to {version}"
 commit_author = "amplitude-sdk-bot <amplitude-sdk-bot@users.noreply.github.com>"
+
+[tool.semantic_release.publish]
+upload_to_vcs_release = true
+
+[tool.semantic_release.branches.main]
+match = "(main|master)"
+prerelease = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version_variable = [
 ]
 major_on_zero = true
 branch = "main"
-upload_to_PyPI = true
+upload_to_PyPI = false
 upload_to_release = true
 build_command = "pip install build && python -m build"
 version_source = "commit"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,8 @@ upload_to_vcs_release = true
 [tool.semantic_release.branches.main]
 match = "(main|master)"
 prerelease = false
+
+[tool.semantic_release.branches.alpha]
+match = "^(?!.*main|master).*$"
+prerelease = true
+prerelease_token = "alpha"


### PR DESCRIPTION
## Summary
- **SHA pin all external GitHub Actions** to full commit SHAs across all 6 workflows (P0)
- **Migrate PyPI and TestPyPI publishing to OIDC trusted publishers**, removing long-lived `PYPI_API_TOKEN` and `TEST_PYPI_API_TOKEN` secrets (P0)
- **Add CODEOWNERS file** requiring `@amplitude/experiment-sdk` review for workflows, build config, and package metadata (P1)

Addresses [SKY-10115](https://amplitude.atlassian.net/browse/SKY-10115) per the supply chain security baseline defined in [SKY-10076](https://amplitude.atlassian.net/browse/SKY-10076).

## Changes

### OIDC Trusted Publishers (P0)
- `publish-to-pypi.yml`: Replaced `REPOSITORY_USERNAME`/`REPOSITORY_PASSWORD` token auth with `pypa/gh-action-pypi-publish` using OIDC. Added `id-token: write` permission. Changed environment from `Unit Test` to `pypi`. Disabled semantic-release's built-in PyPI upload (`upload_to_PyPI = false` in pyproject.toml) in favor of the dedicated publish action.
- `publish-to-test-pypi.yml`: Replaced `user`/`password` token auth with OIDC trusted publishing. Added `testpypi` environment and `id-token: write` permission.

### SHA Pinning (P0)
All external actions pinned to full commit SHAs with version comments:
| Action | Version | Workflows |
|--------|---------|-----------|
| `actions/checkout` | v3, v2 | all |
| `actions/setup-python` | v6 | all |
| `lannonbr/repo-permission-check-action` | 2.0.2 | publish-to-pypi, publish-to-test-pypi |
| `pypa/gh-action-pypi-publish` | v1.13.0 | publish-to-pypi, publish-to-test-pypi |
| `JamesIves/github-pages-deploy-action` | 4.1.5 | docs |
| `atlassian/gajira-login` | master | jira-issue-create |
| `atlassian/gajira-create` | master | jira-issue-create |

### CODEOWNERS (P1)
Added `.github/CODEOWNERS` requiring `@amplitude/sdk` review for:
- `.github/workflows/`
- `.github/CODEOWNERS`
- `setup.py`
- `pyproject.toml`

## Prerequisites (manual steps required before merging)
1. **Configure PyPI trusted publisher**: On [pypi.org](https://pypi.org/manage/project/amplitude-experiment/settings/publishing/), add a trusted publisher for `amplitude/experiment-python-server` workflow `publish-to-pypi.yml` environment `pypi`
2. **Configure TestPyPI trusted publisher**: On [test.pypi.org](https://test.pypi.org/manage/project/amplitude-experiment/settings/publishing/), add a trusted publisher for `amplitude/experiment-python-server` workflow `publish-to-test-pypi.yml` environment `testpypi`
3. **Create GitHub environments**: Create `pypi` and `testpypi` environments in [repo settings](https://github.com/amplitude/experiment-python-server/settings/environments)
4. **Revoke old tokens**: After verifying OIDC publishing works, remove `PYPI_API_TOKEN` and `TEST_PYPI_API_TOKEN` from repo secrets

## Test plan
- [ ] Configure PyPI and TestPyPI trusted publishers (see prerequisites above)
- [ ] Create `pypi` and `testpypi` GitHub environments
- [ ] Run `Publish to TestPyPI` workflow to verify OIDC publishing works
- [ ] Run `Publish to PyPI` workflow with `dryRun=true` to verify dry run still works
- [ ] Run `Publish to PyPI` workflow with `dryRun=false` to verify full release works
- [ ] Revoke old `PYPI_API_TOKEN` and `TEST_PYPI_API_TOKEN` secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SKY-10115]: https://amplitude.atlassian.net/browse/SKY-10115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SKY-10076]: https://amplitude.atlassian.net/browse/SKY-10076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release/publishing workflows and semantic-release configuration; mistakes could break automated releases or publish to the wrong registry, though changes are largely CI/security hardening.
> 
> **Overview**
> **Hardens CI/release supply chain** by adding a repo-wide `.github/CODEOWNERS` default owner and pinning all GitHub Actions in workflows to immutable commit SHAs.
> 
> **Reworks PyPI/TestPyPI publishing** to use OIDC trusted publishing via `pypa/gh-action-pypi-publish`, adding explicit `permissions` (incl. `id-token: write`), running tests before publishing, and switching semantic-release usage to the `python-semantic-release` action (with updated `pyproject.toml` semantic-release keys/branch config) rather than token-based uploads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31396ec18ff7a3889c4b7a693be11195daa1000b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->