### PR TITLE
fix: include experiment key on local-eval exposure events

### DIFF
--- a/src/amplitude_experiment/exposure/exposure_service.py
+++ b/src/amplitude_experiment/exposure/exposure_service.py
@@ -41,6 +41,9 @@ def to_exposure_events(exposure: Exposure, ttl_millis: int) -> List[BaseEvent]:
             event_properties['[Experiment] Variant'] = variant.key
         elif variant.value:
             event_properties['[Experiment] Variant'] = variant.value
+        experiment_key = variant.metadata.get('experimentKey') if variant.metadata is not None else None
+        if experiment_key:
+            event_properties['[Experiment] Experiment Key'] = experiment_key
         if variant.metadata:
             event_properties['metadata'] = variant.metadata
 

--- a/tests/local/exposure/exposure_service_test.py
+++ b/tests/local/exposure/exposure_service_test.py
@@ -50,6 +50,13 @@ class ExposureServiceTestCase(unittest.TestCase):
         })
         empty_metadata = Variant(key='on', value='on')
         empty_variant = Variant()
+        with_experiment_key = Variant(key='treatment', value='treatment', metadata={
+            'segmentName': 'All Other Users',
+            'flagType': 'experiment',
+            'flagVersion': 10,
+            'default': False,
+            'experimentKey': 'exp-1',
+        })
         results = {
             'basic': basic,
             'different_value': different_value,
@@ -59,12 +66,13 @@ class ExposureServiceTestCase(unittest.TestCase):
             'partial_metadata': partial_metadata,
             'empty_metadata': empty_metadata,
             'empty_variant': empty_variant,
+            'with_experiment_key': with_experiment_key,
         }
         exposure = Exposure(user, results)
         events = to_exposure_events(exposure, DAY_MILLIS)
         # Should exclude default (default=True) only
-        # basic, different_value, mutex, holdout, partial_metadata, empty_metadata, empty_variant = 7 events
-        self.assertEqual(7, len(events))
+        # basic, different_value, mutex, holdout, partial_metadata, empty_metadata, empty_variant, with_experiment_key = 8 events
+        self.assertEqual(8, len(events))
         
         # Verify empty_variant is included
         empty_variant_events = [e for e in events if e.event_properties.get('[Experiment] Flag Key') == 'empty_variant']
@@ -95,6 +103,12 @@ class ExposureServiceTestCase(unittest.TestCase):
             # If variant has no key or value (empty_variant), variant property may not be set
             if variant.metadata:
                 self.assertEqual(variant.metadata, event.event_properties.get('metadata'))
+
+            # Validate experiment key is lifted to top-level event property when present
+            if flag_key == 'with_experiment_key':
+                self.assertEqual('exp-1', event.event_properties.get('[Experiment] Experiment Key'))
+            else:
+                self.assertNotIn('[Experiment] Experiment Key', event.event_properties)
             
             # Validate user properties
             user_properties = event.user_properties


### PR DESCRIPTION
## Summary

- Local evaluation exposure events from `to_exposure_events` carried `experimentKey` only inside the `metadata` blob — the top-level event property `[Experiment] Experiment Key` was never set, so custom reports keying off it saw no value for local-eval customers.
- Fix: when `variant.metadata['experimentKey']` is present, set `event_properties['[Experiment] Experiment Key']`. Additive and backwards-compatible — `metadata`, `[Experiment] Flag Key`, `[Experiment] Variant`, user properties, and `insert_id` are unchanged.
- Mirrors [amplitude/experiment-node-server#83](https://github.com/amplitude/experiment-node-server/pull/83).

## Test plan

- [x] Added `with_experiment_key` fixture to `ExposureServiceTestCase.test_to_exposure_events`. Asserts `[Experiment] Experiment Key` equals `'exp-1'` for that flag and is absent for the others.
- [x] Updated event count expectation accordingly.
- [x] `python -m unittest tests.local.exposure.exposure_service_test` — 2 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk additive change to analytics event payloads: it only copies `metadata.experimentKey` into a new top-level event property and updates unit coverage.
> 
> **Overview**
> Local-eval exposure events generated by `to_exposure_events` now *lift* `variant.metadata['experimentKey']` into a top-level event property, setting `[Experiment] Experiment Key` when present (while still keeping the full `metadata` blob).
> 
> Tests extend `ExposureServiceTestCase.test_to_exposure_events` with a `with_experiment_key` fixture, update the expected event count, and assert the new property is present only for that flag and absent otherwise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bc87f34b8935f8b8e29ed447f651c6f9ede0f38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->