### PR TITLE
feat: support flagKeys param for remote evaluations

### DIFF
--- a/src/amplitude_experiment/remote/client.py
+++ b/src/amplitude_experiment/remote/client.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import threading
 import time
@@ -143,6 +144,10 @@ class RemoteEvaluationClient:
             headers['X-Amp-Exp-Track'] = "track" if fetch_options.tracksAssignment else "no-track"
         if fetch_options and fetch_options.tracksExposure is not None:
             headers['X-Amp-Exp-Exposure-Track'] = "track" if fetch_options.tracksExposure else "no-track"
+        if fetch_options and fetch_options.flagKeys:
+            headers['X-Amp-Exp-Flag-Keys'] = base64.urlsafe_b64encode(
+                json.dumps(fetch_options.flagKeys).encode("utf-8")
+            ).rstrip(b"=").decode("utf-8")
 
         conn = self._connection_pool.acquire()
         body = user_context.to_json().encode('utf8')

--- a/src/amplitude_experiment/remote/client.py
+++ b/src/amplitude_experiment/remote/client.py
@@ -146,7 +146,7 @@ class RemoteEvaluationClient:
             headers['X-Amp-Exp-Exposure-Track'] = "track" if fetch_options.tracksExposure else "no-track"
         if fetch_options and fetch_options.flagKeys:
             headers['X-Amp-Exp-Flag-Keys'] = base64.urlsafe_b64encode(
-                json.dumps(fetch_options.flagKeys).encode("utf-8")
+                json.dumps(fetch_options.flagKeys, separators=(",", ":")).encode("utf-8")
             ).rstrip(b"=").decode("utf-8")
 
         conn = self._connection_pool.acquire()

--- a/src/amplitude_experiment/remote/fetch_options.py
+++ b/src/amplitude_experiment/remote/fetch_options.py
@@ -1,14 +1,24 @@
-from typing import Optional
+from typing import List, Optional
+
+
 class FetchOptions:
-    def __init__(self, tracksAssignment: Optional[bool] = None, tracksExposure: Optional[bool] = None):
+    def __init__(
+        self,
+        tracksAssignment: Optional[bool] = None,
+        tracksExposure: Optional[bool] = None,
+        flagKeys: Optional[List[str]] = None,
+    ):
         """
         Fetch Options
             Parameters:
                 tracksAssignment (Optional[bool]): Whether to track the assignment. The default None uses the server's default behavior (track the assignment event).
                 tracksExposure (Optional[bool]): Whether to track the exposure. The default None uses the server's default behavior (don't track the exposure event).
+                flagKeys (Optional[List[str]]): Specific flag keys to evaluate and set variants for.
         """
         self.tracksAssignment = tracksAssignment
         self.tracksExposure = tracksExposure
+        self.flagKeys = flagKeys
 
     def __str__(self):
-        return f"FetchOptions(tracksAssignment={self.tracksAssignment}, tracksExposure={self.tracksExposure})"
+        return (f"FetchOptions(tracksAssignment={self.tracksAssignment}, "
+                f"tracksExposure={self.tracksExposure}, flagKeys={self.flagKeys})")

--- a/tests/remote/client_test.py
+++ b/tests/remote/client_test.py
@@ -88,7 +88,7 @@ class RemoteEvaluationClientTestCase(unittest.TestCase):
             mock_conn.request.assert_called_once_with('POST', '/sdk/v2/vardata?v=0', mock.ANY, {
                 'Authorization': f"Api-Key {API_KEY}",
                 'Content-Type': 'application/json;charset=utf-8',
-                'X-Amp-Exp-Flag-Keys': 'WyJmbGFnLWEiLCAiZmxhZy1iIl0'  # gitleaks:allow
+                'X-Amp-Exp-Flag-Keys': 'WyJmbGFnLWEiLCJmbGFnLWIiXQ'
             })
 
             mock_conn.request.reset_mock()

--- a/tests/remote/client_test.py
+++ b/tests/remote/client_test.py
@@ -81,6 +81,25 @@ class RemoteEvaluationClientTestCase(unittest.TestCase):
                 'X-Amp-Exp-Exposure-Track': 'no-track'
             })
 
+            mock_conn.request.reset_mock()
+
+            variants = client.fetch_v2(user, FetchOptions(flagKeys=['flag-a', 'flag-b']))
+            self.assertIn('sdk-ci-test', variants)
+            mock_conn.request.assert_called_once_with('POST', '/sdk/v2/vardata?v=0', mock.ANY, {
+                'Authorization': f"Api-Key {API_KEY}",
+                'Content-Type': 'application/json;charset=utf-8',
+                'X-Amp-Exp-Flag-Keys': 'WyJmbGFnLWEiLCAiZmxhZy1iIl0'  # gitleaks:allow
+            })
+
+            mock_conn.request.reset_mock()
+
+            variants = client.fetch_v2(user, FetchOptions(flagKeys=[]))
+            self.assertIn('sdk-ci-test', variants)
+            mock_conn.request.assert_called_once_with('POST', '/sdk/v2/vardata?v=0', mock.ANY, {
+                'Authorization': f"Api-Key {API_KEY}",
+                'Content-Type': 'application/json;charset=utf-8'
+            })
+
     @parameterized.expand([
         (300, "Fetch Exception 300", True),
         (400, "Fetch Exception 400", False),


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Experiment Python Server SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

This PR adds support for flagKeys param to fetch_v2() to allow emitting exposure events for designated flagKeys, in line with implementation matching core amplitude experiment sdk [reference](https://github.com/amplitude/experiment-js-client/blob/1f55cc12c2e0dd0f3f5405857cd19859af99c634/packages/experiment-core/src/api/evaluation-api.ts#L60)

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-python-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No, Backwards compatible.

Hello team. Recently we ran into an issue where when setting `fetch_v2(trackExposure=True)`, this would cause firing exposure events for all our experiments in a deployment. The workaround fix for this is to call the v1 Experiment Evaluation API directly ; [reference](https://amplitude.com/docs/apis/experiment/experiment-evaluation-api#evaluation-query-parameters) that allows setting  `flag_keys` explicitly to prevent firing exposure events for all keys in a deployment. From my understanding, this is supported in the node.js sdk and the [core experiment sdk](https://github.com/amplitude/experiment-js-client/blob/main/packages/experiment-core/src/api/evaluation-api.ts#L61), so we should support it in the python sdk as well.

Cheers! 🥳 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, backward-compatible optional parameter and request header with test coverage; no auth or data-model changes.
> 
> **Overview**
> Adds optional **`flagKeys`** on `FetchOptions` so `fetch_v2()` can ask the evaluation API to focus on specific flags (aligned with other Experiment SDKs).
> 
> When `flagKeys` is a non-empty list, **`RemoteEvaluationClient`** sets **`X-Amp-Exp-Flag-Keys`** to a URL-safe base64 encoding of the JSON array (padding stripped). An empty list omits the header, matching existing behavior for assignment/exposure tracking options.
> 
> Unit tests assert the header value for sample keys and that **`flagKeys=[]`** does not add the header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2654122b88bd9c1e9e70fdc4bbc4beb4844e4c25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->