### PR TITLE
feat: make remote evaluation connection pool size configurable

### DIFF
--- a/src/amplitude_experiment/remote/client.py
+++ b/src/amplitude_experiment/remote/client.py
@@ -172,8 +172,8 @@ class RemoteEvaluationClient:
     def __setup_connection_pool(self):
         scheme, _, host = self.config.server_url.split('/', 3)
         timeout = self.config.fetch_timeout_millis / 1000
-        self._connection_pool = HTTPConnectionPool(host, max_size=1, idle_timeout=30,
-                                                   read_timeout=timeout, scheme=scheme)
+        self._connection_pool = HTTPConnectionPool(host, max_size=self.config.connection_pool_max_size,
+                                                   idle_timeout=30, read_timeout=timeout, scheme=scheme)
 
     def close(self) -> None:
         """

--- a/src/amplitude_experiment/remote/config.py
+++ b/src/amplitude_experiment/remote/config.py
@@ -18,6 +18,7 @@ class RemoteEvaluationConfig:
                  fetch_retry_backoff_scalar=1.5,
                  fetch_retry_timeout_millis=10000,
                  server_zone: ServerZone = ServerZone.US,
+                 connection_pool_max_size=1,
                  logger=None):
         """
         Initialize a config
@@ -34,6 +35,10 @@ class RemoteEvaluationConfig:
                 fetch_retry_backoff_scalar (float): Scales the minimum backoff exponentially.
                 fetch_retry_timeout_millis (int): The request timeout for retrying fetch requests.
                 server_zone (str): Select the Amplitude data center to get flags and variants from, US or EU.
+                connection_pool_max_size (int): The maximum number of HTTP connections kept in the fetch connection
+                  pool, and therefore the maximum number of concurrent fetch requests. Additional concurrent fetches
+                  beyond this limit block waiting for a connection to be released. Defaults to 1 (all fetches in the
+                  process share a single keep-alive connection).
                 logger (logging.Logger): Optional logger instance. If provided, this logger will be used instead of
                   creating a new one. The debug flag only applies when no logger is provided.
 
@@ -49,6 +54,7 @@ class RemoteEvaluationConfig:
         self.fetch_retry_backoff_scalar = fetch_retry_backoff_scalar
         self.fetch_retry_timeout_millis = fetch_retry_timeout_millis
         self.server_zone = server_zone
+        self.connection_pool_max_size = connection_pool_max_size
         if server_url == DEFAULT_SERVER_URL and server_zone == ServerZone.EU:
             self.server_url = EU_SERVER_URL
 

--- a/tests/remote/client_test.py
+++ b/tests/remote/client_test.py
@@ -124,3 +124,15 @@ class RemoteEvaluationClientTestCase(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class RemoteEvaluationClientConnectionPoolTestCase(unittest.TestCase):
+
+    def test_connection_pool_defaults_to_single_connection(self):
+        with RemoteEvaluationClient(API_KEY) as client:
+            self.assertEqual(client._connection_pool.max_size, 1)
+
+    def test_connection_pool_size_is_configurable(self):
+        config = RemoteEvaluationConfig(connection_pool_max_size=8)
+        with RemoteEvaluationClient(API_KEY, config) as client:
+            self.assertEqual(client._connection_pool.max_size, 8)

--- a/tests/remote/config_test.py
+++ b/tests/remote/config_test.py
@@ -68,3 +68,15 @@ class RemoteEvaluationConfigLoggerTestCase(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class RemoteEvaluationConfigConnectionPoolTestCase(unittest.TestCase):
+    """Tests for RemoteEvaluationConfig connection pool configuration"""
+
+    def test_connection_pool_max_size_defaults_to_one(self):
+        config = RemoteEvaluationConfig()
+        self.assertEqual(config.connection_pool_max_size, 1)
+
+    def test_connection_pool_max_size_is_stored(self):
+        config = RemoteEvaluationConfig(connection_pool_max_size=8)
+        self.assertEqual(config.connection_pool_max_size, 8)


### PR DESCRIPTION
### Summary

The remote evaluation client hardcodes its connection pool to a single connection:

```python
# remote/client.py
self._connection_pool = HTTPConnectionPool(host, max_size=1, idle_timeout=30, ...)
```

and acquires it with no timeout, so every `fetch_v2` in a process serializes through one HTTP connection and concurrent callers block indefinitely in `pool.acquire()`. `fetch_timeout_millis` bounds the socket read only — not the queue wait — so under concurrent server-side usage during a period of elevated evaluation-API latency, queued callers can be blocked far longer than any configured timeout, pinning worker threads/greenlets. We hit exactly this in production: request handlers stalled inside `connection_pool.acquire()` while the fetch timeout never applied.

#### Observed impact

To illustrate the magnitude: during a ~10-minute window of elevated evaluation-API latency, this serialization amplified the slowdown into tens of thousands of failed requests across several of our services — the worst-affected service logged ~13,000 request errors, and a downstream dependent that had correctly bounded its *own* call timeouts logged ~4,700 more as cascade. Two properties made it unusually hard to diagnose:

1. **It's invisible to fetch-level telemetry.** Callers queued in `acquire()` never reach the socket, so no fetch error or timeout is ever recorded — monitoring built on fetch outcomes shows a healthy SDK while worker threads/greenlets starve underneath it.
2. **It outlives the upstream event.** The acquire queue is a backlog: ours kept failing requests for ~7 minutes after the evaluation API had fully recovered, extending the impact window ~70% past the underlying degradation.

Because the pool size is hardcoded, no combination of the SDK's existing config options can mitigate this today.

#### Change

This PR adds `connection_pool_max_size` to `RemoteEvaluationConfig` (default `1`, preserving existing behavior exactly) and passes it through to the pool, so concurrent server-side callers can size the pool to their needs:

```python
config = RemoteEvaluationConfig(
    fetch_timeout_millis=1500,
    connection_pool_max_size=8,
)
```

This also aligns the Python SDK with the Node server SDK, whose `https.Agent({ keepAlive: true })` does not limit concurrent sockets.

The pool implementation already supports arbitrary sizes — this only exposes the existing parameter through config. Tests added for the config default, config pass-through, and the resulting pool size on the client.

A natural follow-up would be bounding the `acquire()` wait itself (e.g. applying `fetch_timeout_millis` to queue wait, or a separate `acquire_timeout_millis`) so callers fail fast instead of queueing unboundedly — happy to open that separately if there's interest.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-python-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, backward-compatible config surface with default behavior unchanged; only affects fetch concurrency and connection reuse.
> 
> **Overview**
> Adds **`connection_pool_max_size`** to `RemoteEvaluationConfig` (default **1**, unchanged from the previous hardcoded value) and wires it into `RemoteEvaluationClient`’s `HTTPConnectionPool` instead of a fixed `max_size=1`.
> 
> Callers can raise the limit so multiple concurrent `fetch_v2` calls can use separate keep-alive connections instead of blocking on `pool.acquire()` when the single connection is busy. Docs on the config field describe that extra concurrent fetches wait for a released connection.
> 
> Unit tests cover the config default/storage and that the client pool’s `max_size` reflects the setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12eb4b8fd0baeb577d644568ed5906a6f72390e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
