### PR TITLE
fix: bound remote fetch connection pool acquire wait by fetch timeout

### DIFF
--- a/src/amplitude_experiment/remote/client.py
+++ b/src/amplitude_experiment/remote/client.py
@@ -149,10 +149,13 @@ class RemoteEvaluationClient:
                 json.dumps(fetch_options.flagKeys, separators=(",", ":")).encode("utf-8")
             ).rstrip(b"=").decode("utf-8")
 
+        acquire_timeout_millis = self.config.fetch_pool_acquire_timeout_millis
         try:
-            conn = self._connection_pool.acquire(timeout=self.config.fetch_timeout_millis / 1000)
+            conn = self._connection_pool.acquire(
+                timeout=acquire_timeout_millis / 1000 if acquire_timeout_millis is not None else None
+            )
         except EmptyPoolError:
-            raise TimeoutError(f"Timed out waiting {self.config.fetch_timeout_millis}ms for a connection "
+            raise TimeoutError(f"Timed out waiting {acquire_timeout_millis}ms for a connection "
                                f"from the pool (max_size={self._connection_pool.max_size})")
         body = user_context.to_json().encode('utf8')
         if len(body) > 8000:

--- a/src/amplitude_experiment/remote/client.py
+++ b/src/amplitude_experiment/remote/client.py
@@ -7,7 +7,7 @@ from typing import Any, Dict
 
 from .config import RemoteEvaluationConfig
 from .fetch_options import FetchOptions
-from ..connection_pool import HTTPConnectionPool
+from ..connection_pool import EmptyPoolError, HTTPConnectionPool
 from ..exception import FetchException
 from ..user import User
 from ..util.deprecated import deprecated
@@ -149,7 +149,11 @@ class RemoteEvaluationClient:
                 json.dumps(fetch_options.flagKeys, separators=(",", ":")).encode("utf-8")
             ).rstrip(b"=").decode("utf-8")
 
-        conn = self._connection_pool.acquire()
+        try:
+            conn = self._connection_pool.acquire(timeout=self.config.fetch_timeout_millis / 1000)
+        except EmptyPoolError:
+            raise FetchException(408, f"Timed out waiting {self.config.fetch_timeout_millis}ms for a connection "
+                                      f"from the pool (max_size={self._connection_pool.max_size})")
         body = user_context.to_json().encode('utf8')
         if len(body) > 8000:
             self.logger.warning(f"[Experiment] encoded user object length ${len(body)} "

--- a/src/amplitude_experiment/remote/client.py
+++ b/src/amplitude_experiment/remote/client.py
@@ -152,8 +152,8 @@ class RemoteEvaluationClient:
         try:
             conn = self._connection_pool.acquire(timeout=self.config.fetch_timeout_millis / 1000)
         except EmptyPoolError:
-            raise FetchException(408, f"Timed out waiting {self.config.fetch_timeout_millis}ms for a connection "
-                                      f"from the pool (max_size={self._connection_pool.max_size})")
+            raise TimeoutError(f"Timed out waiting {self.config.fetch_timeout_millis}ms for a connection "
+                               f"from the pool (max_size={self._connection_pool.max_size})")
         body = user_context.to_json().encode('utf8')
         if len(body) > 8000:
             self.logger.warning(f"[Experiment] encoded user object length ${len(body)} "

--- a/src/amplitude_experiment/remote/config.py
+++ b/src/amplitude_experiment/remote/config.py
@@ -17,6 +17,7 @@ class RemoteEvaluationConfig:
                  fetch_retry_backoff_max_millis=10000,
                  fetch_retry_backoff_scalar=1.5,
                  fetch_retry_timeout_millis=10000,
+                 fetch_pool_acquire_timeout_millis=None,
                  server_zone: ServerZone = ServerZone.US,
                  logger=None):
         """
@@ -25,8 +26,7 @@ class RemoteEvaluationConfig:
                 debug (bool): Set to true to log some extra information to the console.
                 server_url (str): The server endpoint from which to request variants.
                 fetch_timeout_millis (int): The request timeout, in milliseconds, used when fetching variants
-                  triggered by calling start() or setUser(). Also bounds how long a fetch may wait to acquire a
-                  connection from the connection pool when all connections are in use by concurrent fetches.
+                  triggered by calling start() or setUser().
                 fetch_retries (int): The number of retries to attempt before failing.
                 fetch_retry_backoff_min_millis (int): Retry backoff minimum (starting backoff delay) in milliseconds.
                   The minimum backoff is scaled by `fetch_retry_backoff_scalar` after each retry failure.
@@ -34,6 +34,10 @@ class RemoteEvaluationConfig:
                   greater than the max, the max is used for all subsequent retries.
                 fetch_retry_backoff_scalar (float): Scales the minimum backoff exponentially.
                 fetch_retry_timeout_millis (int): The request timeout for retrying fetch requests.
+                fetch_pool_acquire_timeout_millis (int | None): Maximum time, in milliseconds, a fetch may wait to
+                  acquire a connection from the connection pool when all pooled connections are busy with concurrent
+                  fetches. None (the default) preserves the existing behavior of waiting indefinitely. When set, an
+                  exhausted wait raises TimeoutError, classified for retries exactly like a socket read timeout.
                 server_zone (str): Select the Amplitude data center to get flags and variants from, US or EU.
                 logger (logging.Logger): Optional logger instance. If provided, this logger will be used instead of
                   creating a new one. The debug flag only applies when no logger is provided.
@@ -49,6 +53,7 @@ class RemoteEvaluationConfig:
         self.fetch_retry_backoff_max_millis = fetch_retry_backoff_max_millis
         self.fetch_retry_backoff_scalar = fetch_retry_backoff_scalar
         self.fetch_retry_timeout_millis = fetch_retry_timeout_millis
+        self.fetch_pool_acquire_timeout_millis = fetch_pool_acquire_timeout_millis
         self.server_zone = server_zone
         if server_url == DEFAULT_SERVER_URL and server_zone == ServerZone.EU:
             self.server_url = EU_SERVER_URL

--- a/src/amplitude_experiment/remote/config.py
+++ b/src/amplitude_experiment/remote/config.py
@@ -25,7 +25,8 @@ class RemoteEvaluationConfig:
                 debug (bool): Set to true to log some extra information to the console.
                 server_url (str): The server endpoint from which to request variants.
                 fetch_timeout_millis (int): The request timeout, in milliseconds, used when fetching variants
-                  triggered by calling start() or setUser().
+                  triggered by calling start() or setUser(). Also bounds how long a fetch may wait to acquire a
+                  connection from the connection pool when all connections are in use by concurrent fetches.
                 fetch_retries (int): The number of retries to attempt before failing.
                 fetch_retry_backoff_min_millis (int): Retry backoff minimum (starting backoff delay) in milliseconds.
                   The minimum backoff is scaled by `fetch_retry_backoff_scalar` after each retry failure.

--- a/tests/remote/client_test.py
+++ b/tests/remote/client_test.py
@@ -42,8 +42,13 @@ class RemoteEvaluationClientTestCase(unittest.TestCase):
         user = User(user_id='test_user')
         self.client.fetch_async(user, self.callback_for_async)
 
+    def test_pool_acquire_wait_unbounded_by_default(self):
+        assert RemoteEvaluationConfig().fetch_pool_acquire_timeout_millis is None
+
     def test_fetch_pool_exhausted_times_out(self):
-        client = RemoteEvaluationClient(API_KEY, RemoteEvaluationConfig(fetch_timeout_millis=100))
+        client = RemoteEvaluationClient(
+            API_KEY, RemoteEvaluationConfig(fetch_pool_acquire_timeout_millis=100)
+        )
         # Occupy the pool's only connection so the next fetch must wait for it.
         held = client._connection_pool.acquire()
         try:
@@ -65,7 +70,9 @@ class RemoteEvaluationClientTestCase(unittest.TestCase):
     def test_fetch_v2_pool_exhausted_matches_read_timeout_behavior(self):
         # With fetch_retries=0, a pool-wait timeout must surface exactly like a read
         # timeout: an empty variants dict, not None and not an exception.
-        client = RemoteEvaluationClient(API_KEY, RemoteEvaluationConfig(fetch_timeout_millis=100))
+        client = RemoteEvaluationClient(
+            API_KEY, RemoteEvaluationConfig(fetch_pool_acquire_timeout_millis=100)
+        )
         held = client._connection_pool.acquire()
         try:
             variants = client.fetch_v2(User(user_id='test_user'))

--- a/tests/remote/client_test.py
+++ b/tests/remote/client_test.py
@@ -42,26 +42,37 @@ class RemoteEvaluationClientTestCase(unittest.TestCase):
         user = User(user_id='test_user')
         self.client.fetch_async(user, self.callback_for_async)
 
-    def test_fetch_pool_exhausted_times_out_with_fetch_exception(self):
+    def test_fetch_pool_exhausted_times_out(self):
         client = RemoteEvaluationClient(API_KEY, RemoteEvaluationConfig(fetch_timeout_millis=100))
         # Occupy the pool's only connection so the next fetch must wait for it.
         held = client._connection_pool.acquire()
         try:
             start = time.time()
-            with self.assertRaises(FetchException) as ctx:
+            with self.assertRaises(TimeoutError):
                 client._RemoteEvaluationClient__do_fetch(User(user_id='test_user'))
             elapsed = time.time() - start
-            self.assertEqual(408, ctx.exception.status_code)
             # Must fail promptly (bounded by fetch_timeout_millis), not hang indefinitely.
             self.assertLess(elapsed, 5)
         finally:
             client._connection_pool.release(held)
             client.close()
 
-    def test_pool_acquire_timeout_is_not_retried(self):
-        # Retrying a starved pool would re-enter the same queue; 408 must be non-retryable.
+    def test_pool_acquire_timeout_classified_like_read_timeout(self):
+        # A pool-wait timeout must take the same retry path as a socket read timeout.
         should_retry = RemoteEvaluationClient._RemoteEvaluationClient__should_retry_fetch
-        self.assertFalse(should_retry(FetchException(408, "pool acquire timed out")))
+        self.assertTrue(should_retry(TimeoutError("pool acquire timed out")))
+
+    def test_fetch_v2_pool_exhausted_matches_read_timeout_behavior(self):
+        # With fetch_retries=0, a pool-wait timeout must surface exactly like a read
+        # timeout: an empty variants dict, not None and not an exception.
+        client = RemoteEvaluationClient(API_KEY, RemoteEvaluationConfig(fetch_timeout_millis=100))
+        held = client._connection_pool.acquire()
+        try:
+            variants = client.fetch_v2(User(user_id='test_user'))
+            self.assertEqual({}, variants)
+        finally:
+            client._connection_pool.release(held)
+            client.close()
 
     def test_fetch_failed_with_retry(self):
         with RemoteEvaluationClient(API_KEY, RemoteEvaluationConfig(debug=False, fetch_retries=1,

--- a/tests/remote/client_test.py
+++ b/tests/remote/client_test.py
@@ -1,4 +1,5 @@
 import json
+import time
 import unittest
 from unittest import mock
 
@@ -41,6 +42,27 @@ class RemoteEvaluationClientTestCase(unittest.TestCase):
         user = User(user_id='test_user')
         self.client.fetch_async(user, self.callback_for_async)
 
+    def test_fetch_pool_exhausted_times_out_with_fetch_exception(self):
+        client = RemoteEvaluationClient(API_KEY, RemoteEvaluationConfig(fetch_timeout_millis=100))
+        # Occupy the pool's only connection so the next fetch must wait for it.
+        held = client._connection_pool.acquire()
+        try:
+            start = time.time()
+            with self.assertRaises(FetchException) as ctx:
+                client._RemoteEvaluationClient__do_fetch(User(user_id='test_user'))
+            elapsed = time.time() - start
+            self.assertEqual(408, ctx.exception.status_code)
+            # Must fail promptly (bounded by fetch_timeout_millis), not hang indefinitely.
+            self.assertLess(elapsed, 5)
+        finally:
+            client._connection_pool.release(held)
+            client.close()
+
+    def test_pool_acquire_timeout_is_not_retried(self):
+        # Retrying a starved pool would re-enter the same queue; 408 must be non-retryable.
+        should_retry = RemoteEvaluationClient._RemoteEvaluationClient__should_retry_fetch
+        self.assertFalse(should_retry(FetchException(408, "pool acquire timed out")))
+
     def test_fetch_failed_with_retry(self):
         with RemoteEvaluationClient(API_KEY, RemoteEvaluationConfig(debug=False, fetch_retries=1,
                                                                     fetch_timeout_millis=1)) as client:
@@ -53,7 +75,7 @@ class RemoteEvaluationClientTestCase(unittest.TestCase):
             user = User(user_id='test_user')
 
             mock_conn = mock.MagicMock()
-            client._connection_pool.acquire = lambda: mock_conn
+            client._connection_pool.acquire = lambda **kwargs: mock_conn
             mock_conn.request.return_value = mock.MagicMock(status=200)
             mock_conn.request.return_value.read.return_value = json.dumps({
                 'sdk-ci-test': {


### PR DESCRIPTION
### Summary

Sibling to #77, independently mergeable. #77 makes the connection pool's *size* configurable; this PR makes the time a fetch may *wait* for a connection from that pool configurable — opt-in, with no default-behavior change.

Today the remote client acquires its pooled connection with no timeout:

```python
# remote/client.py
conn = self._connection_pool.acquire()
```

With the pool's default `timeout=None`, the blocking branch is an unbounded `while self.is_pool_empty(): self._lock.wait()` — so when all pooled connections are busy (with the current pool of 1: whenever two fetches overlap during evaluation-API latency), concurrent callers queue **indefinitely**. `fetch_timeout_millis` never applies to this wait; it only bounds the socket read after acquisition. In production we observed request handlers pinned in `acquire()` for the entire duration of an upstream latency event, and the queued backlog continued failing requests for minutes *after* the API recovered (details and magnitude in #77's description).

### Change

Adds `fetch_pool_acquire_timeout_millis` to `RemoteEvaluationConfig`, default `None`:

- **`None` (default): behavior is exactly today's** — the acquire waits indefinitely. No existing user sees any change.
- **When set**: the acquire uses the pool's existing deadline path (`acquire(timeout=...)` raising `EmptyPoolError` — implemented but previously unused), and exhaustion is mapped to a builtin `TimeoutError` with a descriptive message.

`TimeoutError` gets the **same retry classification as the socket read timeout** (`socket.timeout` is the same type on Python ≥ 3.10), so when enabled, both ways a fetch can stall — waiting for a connection, or waiting on the read — are indistinguishable to callers: with `fetch_retries=0` (default) `fetch_v2` returns the usual empty variants result; with retries configured it backs off and raises after exhaustion (each attempt's wait bounded); async callbacks receive the error.

*(An earlier revision raised `FetchException(408)`, which landed in the non-retryable 4xx path where `__fetch_internal` returns silently — `fetch_v2` produced a bare `None` with no error signal. Credit to the Bugbot comment below for flagging it; that swallow behavior for non-retryable 4xx responses predates this PR and may be worth a separate issue.)*

Tests: config defaults to `None`; pool-exhausted fetch with the timeout set raises `TimeoutError` promptly instead of hanging; the timeout is classified retryable like a read timeout; end-to-end `fetch_v2` parity (empty dict at `fetch_retries=0`, not `None`); existing fetch-options test updated for the new `acquire(timeout=...)` signature.

### Question for maintainers: what should the long-term default be?

This PR deliberately ships with no default-behavior change so it's an easy merge. But we'd value your opinion on the end state:

1. **Keep the dedicated opt-in parameter** (this PR as-is)?
2. **Bound the acquire wait by `fetch_timeout_millis` by default**? We suspect users who set `fetch_timeout_millis` believe it already bounds their fetch latency, and an indefinite silent hang is arguably worse than a timely, handleable error — but that's a default-behavior change you may want to schedule for a major version.
3. **Some other shape** (e.g. folding it into a broader concurrency config alongside #77's `connection_pool_max_size`)?

Happy to rework this PR to whichever you prefer.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-python-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no — new optional config; default `None` preserves existing behavior exactly.
