### PR TITLE
fix: flush pending assignment and exposure events on LocalEvaluationClient.stop()

### DIFF
--- a/src/amplitude_experiment/local/client.py
+++ b/src/amplitude_experiment/local/client.py
@@ -1,5 +1,6 @@
+from concurrent.futures import wait
 from threading import Lock
-from typing import Any, List, Dict, Set
+from typing import Any, List, Dict, Set, Optional
 
 from amplitude import Amplitude
 
@@ -158,12 +159,35 @@ class LocalEvaluationClient:
         self._connection_pool = HTTPConnectionPool(host, max_size=1, idle_timeout=30,
                                                    read_timeout=timeout, scheme=scheme)
 
-    def stop(self) -> None:
+    def stop(self, timeout: Optional[float] = 10.0) -> None:
         """
-        Stop polling for flag configurations. Close resource like connection pool with client
+        Stop polling for flag configurations, flush pending assignment and exposure events, and close resources
+        like the connection pool.
+
+            Parameters:
+                timeout (float | None): Maximum time, in seconds, to wait for pending assignment and exposure
+                  events to finish sending before returning. Defaults to 10 seconds. Pass None to wait
+                  indefinitely.
         """
         self.deployment_runner.stop()
         self._connection_pool.close()
+        self.__shutdown_event_services(timeout)
+
+    def __shutdown_event_services(self, timeout: Optional[float]) -> None:
+        instances = [service.amplitude for service in (self.assignment_service, self.exposure_service)
+                     if service is not None]
+        if not instances:
+            return
+        futures = []
+        for instance in instances:
+            futures.extend(f for f in (instance.flush() or []) if f is not None)
+        if futures:
+            _, not_done = wait(futures, timeout=timeout)
+            if not_done:
+                self.logger.warning(f"[Experiment] Stop timed out after {timeout}s waiting for "
+                                    f"{len(not_done)} pending event batch(es) to flush")
+        for instance in instances:
+            instance.shutdown()
 
     def __enter__(self) -> 'LocalEvaluationClient':
         return self

--- a/tests/local/stop_flush_test.py
+++ b/tests/local/stop_flush_test.py
@@ -1,0 +1,78 @@
+import time
+import unittest
+from concurrent.futures import Future
+from unittest.mock import MagicMock
+
+from src.amplitude_experiment import LocalEvaluationClient, LocalEvaluationConfig
+from src.amplitude_experiment.assignment import AssignmentConfig
+from src.amplitude_experiment.exposure.exposure_config import ExposureConfig
+
+API_KEY = 'server-api-key'
+
+
+def completed_future() -> Future:
+    future = Future()
+    future.set_result(None)
+    return future
+
+
+class LocalEvaluationClientStopTestCase(unittest.TestCase):
+
+    def _client_with_event_services(self) -> LocalEvaluationClient:
+        config = LocalEvaluationConfig(
+            assignment_config=AssignmentConfig(api_key='analytics-api-key'),
+            exposure_config=ExposureConfig(api_key='analytics-api-key'),
+        )
+        return LocalEvaluationClient(API_KEY, config)
+
+    def test_stop_flushes_then_shuts_down_assignment_and_exposure(self):
+        client = self._client_with_event_services()
+        assignment_amplitude = MagicMock()
+        assignment_amplitude.flush.return_value = [completed_future()]
+        exposure_amplitude = MagicMock()
+        exposure_amplitude.flush.return_value = [None]
+        client.assignment_service.amplitude = assignment_amplitude
+        client.exposure_service.amplitude = exposure_amplitude
+
+        client.stop()
+
+        assignment_amplitude.flush.assert_called_once()
+        exposure_amplitude.flush.assert_called_once()
+        assignment_amplitude.shutdown.assert_called_once()
+        exposure_amplitude.shutdown.assert_called_once()
+
+    def test_stop_timeout_bounds_wait_on_pending_events(self):
+        client = self._client_with_event_services()
+        never_completes = Future()
+        assignment_amplitude = MagicMock()
+        assignment_amplitude.flush.return_value = [never_completes]
+        client.assignment_service.amplitude = assignment_amplitude
+        client.exposure_service.amplitude = MagicMock(flush=MagicMock(return_value=[]))
+
+        start = time.monotonic()
+        client.stop(timeout=0.2)
+        elapsed = time.monotonic() - start
+
+        self.assertLess(elapsed, 2)
+        assignment_amplitude.shutdown.assert_called_once()
+
+    def test_stop_without_event_services(self):
+        client = LocalEvaluationClient(API_KEY, LocalEvaluationConfig())
+        client.stop()
+
+    def test_context_manager_exit_flushes(self):
+        client = self._client_with_event_services()
+        exposure_amplitude = MagicMock()
+        exposure_amplitude.flush.return_value = [completed_future()]
+        client.assignment_service.amplitude = MagicMock(flush=MagicMock(return_value=[]))
+        client.exposure_service.amplitude = exposure_amplitude
+
+        with client:
+            pass
+
+        exposure_amplitude.flush.assert_called_once()
+        exposure_amplitude.shutdown.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Problem

`LocalEvaluationClient.stop()` stops the flag config poller and closes the connection pool, but never touches the `Amplitude` analytics instances created for the assignment and exposure services. Events still sitting in their buffers — up to `flush_queue_size` per instance, accumulating for up to `flush_interval_millis` (defaults: 200 events / 10s) — are silently dropped.

The analytics SDK does register an atexit shutdown hook, but that only fires on a clean interpreter exit of the main thread. In the environments where server-side local evaluation typically runs (gunicorn/uwsgi workers being recycled, forked job runners, containers receiving SIGKILL after a grace period), that hook frequently never runs — so the tail of assignment/`$exposure` events for every worker lifecycle is lost. `stop()` / the context-manager `__exit__` is the documented lifecycle point, and it should deliver what was tracked.

## Fix

`stop()` now, after stopping the poller and closing the connection pool:

1. Calls `flush()` on the assignment and exposure `Amplitude` instances (public API) and collects the returned futures.
2. Waits for them with a bounded timeout — new `timeout` parameter, **default 10 seconds**, consistent with the SDK's other network timeout defaults. `None` waits indefinitely. On timeout, a warning is logged with the number of unsent batches.
3. Calls `shutdown()` on both instances — after the flush, so events tracked post-`stop()` are dropped deliberately rather than accumulating in a stopped client.

Clients with no assignment/exposure config are unaffected.

## Behavior change

`stop()` previously returned immediately; it can now block up to `timeout` seconds performing network sends. That is the point of the fix, but it is a change — flagging it for review. `stop(timeout=0)` effectively restores fire-and-forget (flush is still triggered; the wait is skipped).

## Tests

`tests/local/stop_flush_test.py`: flush-then-shutdown ordering on both services, timeout bounding with a never-completing future, no-op with no event services, and context-manager exit. The 4 pre-existing errors in `tests/util/user_test.py` occur identically on unmodified `main` in my environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes documented client lifecycle semantics and can block up to 10s on shutdown; behavior is intentional but may affect worker recycle timing in production.
> 
> **Overview**
> **`LocalEvaluationClient.stop()`** now drains buffered assignment and exposure analytics before tearing down, instead of only stopping the flag poller and closing the HTTP pool.
> 
> After the existing shutdown steps, it **`flush()`**es each configured assignment/exposure **`Amplitude`** instance, **`wait()`**s on returned futures up to a new **`timeout`** argument (**10s** default; **`None`** = wait forever), logs a warning if batches remain, then calls **`shutdown()`** on those instances. **`__exit__`** still calls **`stop()`**, so context-manager use gets the same behavior. Clients without assignment/exposure config are unchanged.
> 
> **`stop()`** may now block on network I/O (up to **`timeout`**); **`stop(timeout=0)`** still triggers flush but skips waiting.
> 
> Adds **`tests/local/stop_flush_test.py`** for flush/shutdown ordering, timeout bounding, no-op without event services, and context-manager exit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41c2df708f768fd0acc24e38d3a9a06ac0fcea19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->