### PR TITLE
fix: flush pending assignment and exposure events on LocalEvaluationClient.stop()

### DIFF
--- a/src/amplitude_experiment/local/client.py
+++ b/src/amplitude_experiment/local/client.py
@@ -1,5 +1,6 @@
+from concurrent.futures import wait
 from threading import Lock
-from typing import Any, List, Dict, Set
+from typing import Any, List, Dict, Set, Optional
 
 from amplitude import Amplitude
 
@@ -158,12 +159,34 @@ class LocalEvaluationClient:
         self._connection_pool = HTTPConnectionPool(host, max_size=1, idle_timeout=30,
                                                    read_timeout=timeout, scheme=scheme)
 
-    def stop(self) -> None:
+    def stop(self, timeout: Optional[float] = 10.0) -> None:
         """
-        Stop polling for flag configurations. Close resource like connection pool with client
+        Stop polling for flag configurations, flush pending assignment and exposure events, and close resources
+        like the connection pool.
+
+        The assignment and exposure Amplitude instances are flushed but not shut down, so they remain usable
+        and their caller-provided configurations are not mutated.
+
+            Parameters:
+                timeout (float | None): Maximum time, in seconds, to wait for pending assignment and exposure
+                  events to finish sending before returning. Defaults to 10 seconds. Pass None to wait
+                  indefinitely.
         """
         self.deployment_runner.stop()
         self._connection_pool.close()
+        self.__flush_event_services(timeout)
+
+    def __flush_event_services(self, timeout: Optional[float]) -> None:
+        instances = [service.amplitude for service in (self.assignment_service, self.exposure_service)
+                     if service is not None]
+        futures = []
+        for instance in instances:
+            futures.extend(f for f in (instance.flush() or []) if f is not None)
+        if futures:
+            _, not_done = wait(futures, timeout=timeout)
+            if not_done:
+                self.logger.warning(f"[Experiment] Stop timed out after {timeout}s waiting for "
+                                    f"{len(not_done)} pending event batch(es) to flush")
 
     def __enter__(self) -> 'LocalEvaluationClient':
         return self

--- a/tests/local/stop_flush_test.py
+++ b/tests/local/stop_flush_test.py
@@ -1,0 +1,79 @@
+import time
+import unittest
+from concurrent.futures import Future
+from unittest.mock import MagicMock
+
+from src.amplitude_experiment import LocalEvaluationClient, LocalEvaluationConfig
+from src.amplitude_experiment.assignment import AssignmentConfig
+from src.amplitude_experiment.exposure.exposure_config import ExposureConfig
+
+API_KEY = 'server-api-key'
+
+
+def completed_future() -> Future:
+    future = Future()
+    future.set_result(None)
+    return future
+
+
+class LocalEvaluationClientStopTestCase(unittest.TestCase):
+
+    def _client_with_event_services(self) -> LocalEvaluationClient:
+        config = LocalEvaluationConfig(
+            assignment_config=AssignmentConfig(api_key='analytics-api-key'),
+            exposure_config=ExposureConfig(api_key='analytics-api-key'),
+        )
+        return LocalEvaluationClient(API_KEY, config)
+
+    def test_stop_flushes_assignment_and_exposure_without_shutdown(self):
+        client = self._client_with_event_services()
+        assignment_amplitude = MagicMock()
+        assignment_amplitude.flush.return_value = [completed_future()]
+        exposure_amplitude = MagicMock()
+        exposure_amplitude.flush.return_value = [None]
+        client.assignment_service.amplitude = assignment_amplitude
+        client.exposure_service.amplitude = exposure_amplitude
+
+        client.stop()
+
+        assignment_amplitude.flush.assert_called_once()
+        exposure_amplitude.flush.assert_called_once()
+        # The instances are not shut down: shutdown() would set opt_out=True on the
+        # caller-provided config, silently dropping events for any client reusing it.
+        assignment_amplitude.shutdown.assert_not_called()
+        exposure_amplitude.shutdown.assert_not_called()
+
+    def test_stop_timeout_bounds_wait_on_pending_events(self):
+        client = self._client_with_event_services()
+        never_completes = Future()
+        assignment_amplitude = MagicMock()
+        assignment_amplitude.flush.return_value = [never_completes]
+        client.assignment_service.amplitude = assignment_amplitude
+        client.exposure_service.amplitude = MagicMock(flush=MagicMock(return_value=[]))
+
+        start = time.monotonic()
+        client.stop(timeout=0.2)
+        elapsed = time.monotonic() - start
+
+        self.assertLess(elapsed, 2)
+
+    def test_stop_without_event_services(self):
+        client = LocalEvaluationClient(API_KEY, LocalEvaluationConfig())
+        client.stop()
+
+    def test_context_manager_exit_flushes(self):
+        client = self._client_with_event_services()
+        exposure_amplitude = MagicMock()
+        exposure_amplitude.flush.return_value = [completed_future()]
+        client.assignment_service.amplitude = MagicMock(flush=MagicMock(return_value=[]))
+        client.exposure_service.amplitude = exposure_amplitude
+
+        with client:
+            pass
+
+        exposure_amplitude.flush.assert_called_once()
+        exposure_amplitude.shutdown.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Summary

Flush-only alternative to #79 (credit to @cmyui for the diagnosis, the original implementation, and the tests this PR adapts).

**Problem** (as reported in #79): `LocalEvaluationClient.stop()` stops the flag poller and closes the connection pool but never drains the assignment/exposure `Amplitude` buffers — up to `flush_queue_size` events per instance (defaults: 200 events / 10s window) are silently dropped whenever the analytics SDK's atexit hook doesn't fire (recycled gunicorn/uwsgi workers, forked job runners, containers SIGKILL'd after a grace period).

**Fix**: `stop()` now flushes both `Amplitude` instances and waits for the returned futures with a bounded timeout (new `timeout` parameter, default 10 seconds; `None` waits indefinitely). If batches remain unsent at the deadline, a warning is logged with the count.

**Why flush-only, without `shutdown()`** (the difference from #79): `Amplitude.shutdown()` sets `opt_out = True` on its configuration object — and that configuration is the *caller-provided* `AssignmentConfig`/`ExposureConfig` (both subclass `amplitude.Config`). The mutation outlives the experiment client:

- A new `LocalEvaluationClient` constructed with the same config object silently drops every assignment/exposure event.
- A customer's own `Amplitude` instance sharing that config object is silently opted out too.
- `stop()` → `start()` on the same client would leave tracking permanently dead.

Not shutting down leaves resource teardown exactly as it is on `main` today (the analytics SDK's own exit hook), so there is no regression there — the delivered-events fix is the flush + bounded wait.

**Behavior change**: `stop()` previously returned immediately; it can now block up to `timeout` seconds performing network sends. `stop(timeout=0)` triggers the flush but skips the wait.

**Tests**: `tests/local/stop_flush_test.py` — flush happens and `shutdown()` is *not* called (both services), timeout bounds the wait on a never-completing future, no-op without event services, and context-manager exit. Full suite: 161 tests pass locally; the only errors are the 4 pre-existing `setUpClass` failures from missing `API_KEY`/`EU_API_KEY` environment secrets, identical on unmodified `main`.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-python-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no — `stop()` gains an optional parameter with a safe default; flushing on stop is the documented intent of the lifecycle method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQQHvcxnQ1Qvo6CaQuwKGn

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQQHvcxnQ1Qvo6CaQuwKGn)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> stop() can now block on network I/O during shutdown, which changes lifecycle timing in workers and containers; behavior is bounded by timeout and avoids mutating shared analytics config.
> 
> **Overview**
> **`LocalEvaluationClient.stop()`** now drains buffered assignment and exposure analytics before tearing down the poller and connection pool, instead of returning immediately and risking dropped events when process exit hooks do not run.
> 
> When assignment or exposure services are configured, `stop()` calls **`flush()`** on each underlying **`Amplitude`** instance, waits on the returned futures with a new optional **`timeout`** (default **10s**; **`None`** waits indefinitely), and logs a warning if batches are still pending at the deadline. **`shutdown()`** is intentionally **not** invoked so caller-owned **`AssignmentConfig`** / **`ExposureConfig`** objects are not mutated (e.g. **`opt_out`**).
> 
> The context manager’s **`__exit__`** path uses the same **`stop()`** behavior. New unit tests cover flush without shutdown, timeout bounding, no-op without event services, and context-manager exit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e561f61b5787b89748a6c8aec4b0f5a8bc6c1e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->